### PR TITLE
Fix fetching the previous missed call.

### DIFF
--- a/src/android/MissedCallReceiver.java
+++ b/src/android/MissedCallReceiver.java
@@ -11,6 +11,9 @@ import android.content.Intent;
 import android.database.Cursor;
 import android.os.Bundle;
 
+import java.lang.Thread;
+import java.lang.InterruptedException;
+
 public class MissedCallReceiver extends BroadcastReceiver {
     
     private CallbackContext callback_receive;
@@ -24,7 +27,11 @@ public class MissedCallReceiver extends BroadcastReceiver {
         String state = bundle.getString("state");
         JSONObject result = new JSONObject();
         if (prevCallState.equals("RINGING") && state.equals("IDLE")) {
-
+            try {
+                Thread.sleep(3000);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
             Cursor cursor = context.getContentResolver().query(
                     android.provider.CallLog.Calls.CONTENT_URI, null, null,
                     null, android.provider.CallLog.Calls.DATE + " DESC ");


### PR DESCRIPTION
Currently fetch the wrong missed call when we try to fetch an immediate missed call (e.g. phone number verification)
